### PR TITLE
feat(CI): allow manually running the workflow

### DIFF
--- a/.github/workflows/fetch-upstream.yaml
+++ b/.github/workflows/fetch-upstream.yaml
@@ -1,6 +1,7 @@
 name: Fetch upstream
 
 on:
+  workflow_dispatch: {}
   schedule:
     - cron: 0 0 * * *
 


### PR DESCRIPTION
Seems like the workflow got automatically disabled by Github because of inactivity.
Since the new version just got released, it would be nice if we can just manually run the workflow so next time we can just manually run the workflow immediately in case Github decided to disable the workflow again in the future.
